### PR TITLE
unify case for the sender object in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ to the zabbix server/proxy at "my.zabbix.server.example" on port "10055".
 
     use Zabbix::Sender;
 
-    my $Sender = Zabbix::Sender->new({
+    my $sender = Zabbix::Sender->new({
        'server' => 'my.zabbix.server.example',
        'port' => 10055,
     });
-    $Sender->send('my.zabbix.item','OK');
+    $sender->send('my.zabbix.item','OK');
 
 # SUBROUTINES/METHODS
 
@@ -21,29 +21,29 @@ to the zabbix server/proxy at "my.zabbix.server.example" on port "10055".
 
 Name of the host for which to submit items to Zabbix.  Initialized by \_init\_hostname. You can set it either using
 
-    $Sender->hostname('another.hostname');
+    $sender->hostname('another.hostname');
 
 or during creation time of Zabbix::Sender
 
-    my $Sender = Zabbix::Sender->new({
+    my $sender = Zabbix::Sender->new({
         'server' => 'my.zabbix.server.example',
         'hostname' => 'another.hostname',
     });
 
 You can also query the current setting using
 
-    my $current_hostname = $Sender->hostname();
+    my $current_hostname = $sender->hostname();
 
 ## strict
 
 Use the strict setting to make Zabbix::Sender check the return values from
 Zabbix:
 
-    $Sender->strict(1);
+    $sender->strict(1);
 
 You can also query the current setting using
 
-    my $is_strict = $Sender->strict();
+    my $is_strict = $sender->strict();
 
 ## \_init\_json
 
@@ -82,7 +82,7 @@ Returns undef if everything is alright, a message otherwise.
 This method is called when the strict setting of Zabbix::Sender
 is active:
 
-    my $Sender = Zabbix::Sender->new({
+    my $sender = Zabbix::Sender->new({
         'server' => 'my.zabbix.server.example',
         'strict' => 1,
     });


### PR DESCRIPTION
Some examples used "Sender", some used "sender". While the examples were not directly related, consistency seemed desirable - this unifies it all to "sender"